### PR TITLE
User can query for a customer's open order by calling get_active_customer_order()

### DIFF
--- a/src/methods.py
+++ b/src/methods.py
@@ -8,6 +8,10 @@ def get_all_from_table(table_name=None, db='db.sqlite3'):
         ordering = 'last_name'
     elif table_name.lower() == 'product':
         ordering = 'id'
+    command = 'SELECT * FROM {} ORDER BY {}'.format(table_name, ordering)
+    selection = [row for row in c.execute(command)]
+    conn.commit()
+    conn.close()
     return selection
 
 def complete_order(order_id, pmt_type_id):
@@ -29,11 +33,13 @@ def get_active_customer_order(customer_id=None, db='db.sqlite3'):
     selection = [row for row in c.execute(command)]
     conn.commit()
     conn.close()
-    if selection[0][3] != None:
-        print('Customer {} has no active orders. Please create a new order for the customer if you wish to make any changes.')
+
+    if selection[0][3] != 'None':
+        print('Customer {} has no active orders. Please create a new order for the customer if you wish to make any changes.'.format(customer_id))
         print('Last order was completed on {}'.format(selection[0][3]))
+        return None
     else:
-        return selection[0][0]
+        return selection[0]
 
 def flush_table(table_name=None, db='db.sqlite3'):
     conn = sqlite3.connect(db)

--- a/src/methods.py
+++ b/src/methods.py
@@ -8,17 +8,32 @@ def get_all_from_table(table_name=None, db='db.sqlite3'):
         ordering = 'last_name'
     elif table_name.lower() == 'product':
         ordering = 'id'
-    command = 'SELECT * FROM {} ORDER BY {}'.format(table_name, ordering)
-    selection = [row for row in c.execute(command)]
-    conn.commit()
-    conn.close()
     return selection
 
 def complete_order(order_id, pmt_type_id):
     return (1, 3, '2016-01-21', 5, '2017-01-01')
 
-def get_active_customer_order(customer_id):
-    return 1
+def get_active_customer_order(customer_id=None, db='db.sqlite3'):
+    conn = sqlite3.connect(db)
+    c = conn.cursor()
+    command = '''SELECT o.id, o.customer_id, o.date_begun, o.date_paid
+                 FROM CustomerOrder o
+                 INNER JOIN (
+                    SELECT customer_id, max(date_begun) as MaxDate
+                    FROM CustomerOrder
+                    WHERE customer_id == {0}
+                 ) mco
+                 ON o.customer_id == mco.customer_id
+                 AND o.date_begun == mco.MaxDate
+                 '''.format(customer_id)
+    selection = [row for row in c.execute(command)]
+    conn.commit()
+    conn.close()
+    if selection[0][3] != None:
+        print('Customer {} has no active orders. Please create a new order for the customer if you wish to make any changes.')
+        print('Last order was completed on {}'.format(selection[0][3]))
+    else:
+        return selection[0][0]
 
 def flush_table(table_name=None, db='db.sqlite3'):
     conn = sqlite3.connect(db)

--- a/test/TestDB.py
+++ b/test/TestDB.py
@@ -60,11 +60,20 @@ class TestDatabaseInteractions(unittest.TestCase):
         customer_id = save_to_db("Customer", self.customer_values)
 
         # Insert order and get ID
-        order_values = [None, self.faker.date(), customer_id, None]
 
-        save_to_db("CustomerOrder", order_values)
+        order_values_1 = [None, '2015-01-27', customer_id, '2015-02-27']
+        save_to_db("CustomerOrder", order_values_1)
 
-        order_id = get_active_customer_order(customer_id)
+        order = get_active_customer_order(customer_id)
+        self.assertEqual(None, order)
+
+        order_values_2 = [None, '2007-08-06', customer_id, None]
+        order_values_3 = [None, '2016-01-27', customer_id, None]
+        save_to_db("CustomerOrder", order_values_2)
+        save_to_db("CustomerOrder", order_values_3)
+
+        order = get_active_customer_order(customer_id)
+        self.assertTrue('2016-01-27' in order)
 
         # Insert products and get IDs
         first_product_values = [self.faker.word(), self.faker.text(), self.faker.random_int(), customer_id,
@@ -86,14 +95,14 @@ class TestDatabaseInteractions(unittest.TestCase):
         first_chosen_product_id = product_list[first_chosen_product_from_menu-1][chosen_product_pk_index]
         second_chosen_product_id = product_list[second_chosen_product_from_menu-1][chosen_product_pk_index]
 
-        first_productorder_id = save_to_db("ProductOrder", [order_id, first_chosen_product_id])
-        second_productorder_id = save_to_db("ProductOrder", [order_id, first_chosen_product_id])
-        third_productorder_id = save_to_db("ProductOrder", [order_id, second_chosen_product_id])
+        first_productorder = save_to_db("ProductOrder", [order[0], first_chosen_product_id])
+        second_productorder_id = save_to_db("ProductOrder", [order[0], first_chosen_product_id])
+        third_productorder_id = save_to_db("ProductOrder", [order[0], second_chosen_product_id])
 
         self.assertEqual(first_product_id, first_chosen_product_id)
         # self.assertEqual(second_product_id, second_chosen_product_id)
-        self.assertIsNotNone(order_id)
-        self.assertIsNotNone(first_productorder_id)
+        self.assertIsNotNone(order)
+        self.assertIsNotNone(first_productorder)
         self.assertIsNotNone(second_productorder_id)
         self.assertIsNotNone(third_productorder_id)
 
@@ -176,6 +185,3 @@ class TestDatabaseInteractions(unittest.TestCase):
         flush_table("PaymentType")
         flush_table("CustomerOrder")
         flush_table("ProductOrder")
-
-
-


### PR DESCRIPTION
## Associated Ticket
[User may add a product to active customer's shopping cart](https://github.com/solanum-tuberosums/bangazon_terminal_interface/issues/11)
[User can complete an order](https://github.com/solanum-tuberosums/bangazon_terminal_interface/issues/2)

## Description 
The main purpose of this pull request is to receive peer-review for the get_active_customer_order() method. 

get_active_customer() executes a SQL query that returns only a customer's most recently created order. I wrote this method under the assumption that the logic for _creating new orders_ will prevent a new order from being created if the most recently created order has no completion date. If that method is incorrectly implemented, it will be possible for an incomplete order to lose priority in this method's query and effectively become inaccessible.

If the result of this query shows the date_completed field is not 'None', the method prints an error stating that there is no open order. Then it prints the date the order was completed and finally returns 'None'.

### Changes to test_add_product_to_order() in TestDB.py
I modified the test_add_product_to_order()  to accommodate get_active_customer_order() 's new return value. The test originally assumed that the method would only return the primary key of the current open order. I found that this return value was insufficient for testing purposes. It is essential to test not just that _some_ order's id is returned, but also that the order id belongs to the most recently created order. To that end I now return a tuple of four values which includes the order's creation date.

You may access the active order's fields by referencing these indices:

0: order_id, 1: payment_type_id, 2: date_begun, 3: customer_id, 4: date_paid 

## All Tests Pass
- [x] Yes
- [ ] No
